### PR TITLE
darkscience tor address v3

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -130,7 +130,7 @@ socks5_host = localhost
 socks5_port = 9050
 
 #for tor
-#host = darksci3bfoka7tw.onion
+#host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion
 #socks5 = true
 
 [MESSAGING:server2]


### PR DESCRIPTION
darkscience actually already running a v3 address, just the website isn't updated yet. you can try 
`darksci3bfoka7tw.onion` -> `darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion`

And the tor version works reliably for me lately.

verify:

`torsocks openssl s_client darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion:6697`

> `:irc-eu-1.darkscience.net NOTICE * :*** Could not resolve your hostname: Malformed answer; using your IP address (127.0.0.1) instead.`